### PR TITLE
Possibility to import as a module too

### DIFF
--- a/src/trig.js
+++ b/src/trig.js
@@ -238,7 +238,7 @@ class Trig
         }
     }
 }
-const trig = new Trig;
+window.trig = new Trig;
 
 window.addEventListener("scroll", trig.trigScroll, { passive: true });
 window.addEventListener('resize', trig.trigWindowHeight, { passive: true });


### PR DESCRIPTION
With this small change, is possible to use dynamic import too: import(../pathto/trig.js).then(module => {
        trig.trigInit()
});